### PR TITLE
Changed initializer list order to stop warnings

### DIFF
--- a/firmware/neopixel.cpp
+++ b/firmware/neopixel.cpp
@@ -63,7 +63,7 @@
 #define pinSet(_pin, _hilo) (_hilo ? pinHI(_pin) : pinLO(_pin))
 
 Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, uint8_t t) :
-  numLEDs(n), numBytes(n*3), pin(p), brightness(0), pixels(NULL), type(t), endTime(0)
+  numLEDs(n), numBytes(n*3), type(t), pin(p), brightness(0), pixels(NULL), endTime(0)
 {
   if((pixels = (uint8_t *)malloc(numBytes))) {
     memset(pixels, 0, numBytes);


### PR DESCRIPTION
When running on my Particle Photon using the particle-cli, I was getting the following warnings:
```
In file included from neopixel.cpp:50:0:
neopixel.h: In constructor 'Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t, uint8_t, uint8_t)':
neopixel.h:99:5: warning: 'Adafruit_NeoPixel::pixels' will be initialized after [-Wreorder]
    *pixels;        // Holds LED color values (3 bytes each)
     ^
neopixel.h:95:5: warning:   'const uint8_t Adafruit_NeoPixel::type' [-Wreorder]
     type;          // Pixel type flag (400 vs 800 KHz)
     ^
neopixel.cpp:65:1: warning:   when initialized here [-Wreorder]
 Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, uint8_t t) : 
 ^
```

A silly warning, but I saw [here](http://stackoverflow.com/questions/1564937/gcc-warning-will-be-initialized-after) that it was easy to fix.