### PR TITLE
adds RGBW NeoPixel support (implementation for #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@ Particle-NeoPixel
 
 A library for manipulating NeoPixel RGB LEDs for the Spark Core, Photon, P1 and Electron.
 Implementation based on Adafruit's NeoPixel Library.
-Library currently supports WS2812, WS2812B GRB 800kHz style pixels, strips and sticks!
-WS2811 RGB 400kHz style pixels, strips and sticks!
+
+Supported Pixel Types
+---
+- 800 KHz and 400kHz bitstream WS2812, WS2812B and WS2811
+- 800 KHz bitstream SK6812RGBW (NeoPixel RGBW pixel strips)
+  - (use 'SK6812RGBW' as PIXEL_TYPE)
 
 Also supports these less common pixels
 ---
@@ -15,9 +19,9 @@ Also supports these less common pixels
 
 Components Required
 ---
-- A Neopixel digital RGB LED (get at [adafruit.com](adafruit.com))
-- or a Radio Shack Tri-Color LED Strip (get at [radioshack.com](radioshack.com))
-- A Particle Shield Shield or breakout board to supply neopixel's with 5V (see store at [particle.io](particle.io))
+- A Neopixel digital RGB LED (get at [adafruit.com](https://www.adafruit.com))
+- or a Radio Shack Tri-Color LED Strip (get at [radioshack.com](https://www.radioshack.com))
+- A Particle Shield Shield or breakout board to supply neopixel's with 5V (see store at [particle.io](https://www.particle.io))
 
 Example Usage
 ---
@@ -32,6 +36,67 @@ void setup() {
 }
 void loop() {
   // change your pixel colors and call strip.show() again
+}
+```
+
+More Detailed Example Usage
+---
+
+```cpp
+// IMPORTANT: Set pixel COUNT, PIN and TYPE
+#define PIXEL_COUNT 10
+#define PIXEL_PIN D2
+#define PIXEL_TYPE WS2812B
+
+// Parameter 1 = number of pixels in strip
+//               note: for some stripes like those with the TM1829, you
+//                     need to count the number of segments, i.e. the
+//                     number of controllers in your stripe, not the number
+//                     of individual LEDs!
+// Parameter 2 = pin number (most are valid)
+//               note: if not specified, D2 is selected for you.
+// Parameter 3 = pixel type [ WS2812, WS2812B, WS2812B2, WS2811,
+//                             TM1803, TM1829, SK6812RGBW ]
+//               note: if not specified, WS2812B is selected for you.
+//               note: RGB order is automatically applied to WS2811,
+//                     WS2812/WS2812B/WS2812B2/TM1803 is GRB order.
+//
+// 800 KHz bitstream 800 KHz bitstream (most NeoPixel products
+//               WS2812 (6-pin part)/WS2812B (4-pin part)/SK6812RGBW (RGB+W) )
+//
+// 400 KHz bitstream (classic 'v1' (not v2) FLORA pixels, WS2811 drivers)
+//                   (Radio Shack Tri-Color LED Strip - TM1803 driver
+//                    NOTE: RS Tri-Color LED's are grouped in sets of 3)
+
+Adafruit_NeoPixel strip = Adafruit_NeoPixel(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
+
+// IMPORTANT: To reduce NeoPixel burnout risk, add 1000 uF capacitor across
+// pixel power leads, add 300 - 500 Ohm resistor on first pixel's data input
+// and minimize distance between Arduino and first pixel.  Avoid connecting
+// on a live circuit...if you must, connect GND first.
+
+void setup() {
+  strip.begin();
+  strip.show(); // Initialize all pixels to 'off'
+}
+
+void loop() {
+  // Some example procedures showing how to display to the pixels:
+  // Do not run more than 15 seconds of these, or the b/g tasks
+  // will be blocked.
+  //--------------------------------------------------------------
+
+  // Note, these are not built into the library, check the example
+  // files for these helper functions
+  colorWipe(strip.Color(255, 0, 0), 50); // Red
+  colorWipe(strip.Color(0, 255, 0), 50); // Green
+  colorWipe(strip.Color(0, 0, 255), 50); // Blue
+
+  // SK6812RGBW type strips can do RGB+W
+  // Here we only turn on the WHITE LEDs
+  colorWipe(strip.Color(0, 0, 0, 255), 50); // White
+
+  rainbow(20);
 }
 ```
 

--- a/firmware/examples/a-rainbow.cpp
+++ b/firmware/examples/a-rainbow.cpp
@@ -6,7 +6,8 @@
  */
 
 #include "application.h"
-#include "neopixel/neopixel.h"
+#include "neopixel/neopixel.h" // use for Build IDE
+// #include "neopixel.h" // use for local build
 
 SYSTEM_MODE(AUTOMATIC);
 
@@ -16,6 +17,10 @@ SYSTEM_MODE(AUTOMATIC);
 #define PIXEL_TYPE WS2812B
 
 Adafruit_NeoPixel strip = Adafruit_NeoPixel(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
+
+// Prototypes for local build, ok to leave in for Build IDE
+void rainbow(uint8_t wait);
+uint32_t Wheel(byte WheelPos);
 
 void setup()
 {

--- a/firmware/examples/extra-examples.cpp
+++ b/firmware/examples/extra-examples.cpp
@@ -1,8 +1,11 @@
 /*-------------------------------------------------------------------------
-  Spark Core, Photon, P1 and Electron library to control WS2811/WS2812 based RGB
-  LED devices such as Adafruit NeoPixel strips.
-  Currently handles 800 KHz and 400kHz bitstream on Spark Core and Photon,
-  WS2812, WS2812B and WS2811.
+  Spark Core, Photon, P1 and Electron library to control WS2811/WS2812
+  based RGB LED devices such as Adafruit NeoPixel strips.
+
+  Supports:
+  - 800 KHz and 400kHz bitstream WS2812, WS2812B and WS2811
+  - 800 KHz bitstream SK6812RGBW (NeoPixel RGBW pixel strips)
+    (use 'SK6812RGBW' as PIXEL_TYPE)
 
   Also supports:
   - Radio Shack Tri-Color Strip with TM1803 controller 400kHz bitstream.
@@ -31,9 +34,8 @@
 /* ======================= includes ================================= */
 
 #include "application.h"
-#include "neopixel/neopixel.h"
-
-SYSTEM_MODE(AUTOMATIC);
+#include "neopixel/neopixel.h" // use for Build IDE
+// #include "neopixel.h" // use for local build
 
 /* ======================= prototypes =============================== */
 
@@ -44,6 +46,8 @@ void rainbowCycle(uint8_t wait);
 uint32_t Wheel(byte WheelPos);
 
 /* ======================= extra-examples.cpp ======================== */
+
+SYSTEM_MODE(AUTOMATIC);
 
 // IMPORTANT: Set pixel COUNT, PIN and TYPE
 #define PIXEL_COUNT 10
@@ -57,13 +61,14 @@ uint32_t Wheel(byte WheelPos);
 //                     of individual LEDs!
 // Parameter 2 = pin number (most are valid)
 //               note: if not specified, D2 is selected for you.
-// Parameter 3 = pixel type [ WS2812, WS2812B, WS2811, TM1803, TM1829 ]
+// Parameter 3 = pixel type [ WS2812, WS2812B, WS2812B2, WS2811,
+//                             TM1803, TM1829, SK6812RGBW ]
 //               note: if not specified, WS2812B is selected for you.
 //               note: RGB order is automatically applied to WS2811,
-//                     WS2812/WS2812B/TM1803 is GRB order.
+//                     WS2812/WS2812B/WS2812B2/TM1803 is GRB order.
 //
-// 800 KHz bitstream 800 KHz bitstream (most NeoPixel products ...
-//                         ... WS2812 (6-pin part)/WS2812B (4-pin part) )
+// 800 KHz bitstream 800 KHz bitstream (most NeoPixel products
+//               WS2812 (6-pin part)/WS2812B (4-pin part)/SK6812RGBW (RGB+W) )
 //
 // 400 KHz bitstream (classic 'v1' (not v2) FLORA pixels, WS2811 drivers)
 //                   (Radio Shack Tri-Color LED Strip - TM1803 driver
@@ -83,7 +88,7 @@ void setup() {
 
 void loop() {
   // Some example procedures showing how to display to the pixels:
-  // Do not run more than one of these at a time, or the b/g tasks
+  // Do not run more than 15 seconds of these, or the b/g tasks
   // will be blocked.
   //--------------------------------------------------------------
 

--- a/firmware/examples/rgbw-strandtest.cpp
+++ b/firmware/examples/rgbw-strandtest.cpp
@@ -1,0 +1,257 @@
+/*
+ * This is a RGB+W NeoPixel example, see extra-examples.cpp for a version
+ * with more explantory documentation, example routines, how to
+ * hook up your pixels and all of the pixel types that are supported.
+ *
+ */
+
+/* ======================= includes ================================= */
+
+#include "application.h"
+#include "neopixel.h"
+
+/* ======================= prototypes =============================== */
+
+void colorAll(uint32_t c, uint8_t wait);
+void colorWipe(uint32_t c, uint8_t wait);
+void rainbow(uint8_t wait);
+void rainbowCycle(uint8_t wait);
+uint32_t Wheel(byte WheelPos);
+
+/* ======================= rgbw-strandtest.cpp ====================== */
+
+SYSTEM_MODE(AUTOMATIC);
+
+// IMPORTANT: Set pixel COUNT, PIN and TYPE
+#define PIXEL_PIN D2
+#define PIXEL_COUNT 24
+#define PIXEL_TYPE SK6812RGBW
+#define BRIGHTNESS 50 // 0 - 255
+
+Adafruit_NeoPixel strip = Adafruit_NeoPixel(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
+
+int gamma[] = {
+    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  1,  1,  1,
+    1,  1,  1,  1,  1,  1,  1,  1,  1,  2,  2,  2,  2,  2,  2,  2,
+    2,  3,  3,  3,  3,  3,  3,  3,  4,  4,  4,  4,  4,  5,  5,  5,
+    5,  6,  6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  9,  9,  9, 10,
+   10, 10, 11, 11, 11, 12, 12, 13, 13, 13, 14, 14, 15, 15, 16, 16,
+   17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22, 23, 24, 24, 25,
+   25, 26, 27, 27, 28, 29, 29, 30, 31, 32, 32, 33, 34, 35, 35, 36,
+   37, 38, 39, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 50,
+   51, 52, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 66, 67, 68,
+   69, 70, 72, 73, 74, 75, 77, 78, 79, 81, 82, 83, 85, 86, 87, 89,
+   90, 92, 93, 95, 96, 98, 99,101,102,104,105,107,109,110,112,114,
+  115,117,119,120,122,124,126,127,129,131,133,135,137,138,140,142,
+  144,146,148,150,152,154,156,158,160,162,164,167,169,171,173,175,
+  177,180,182,184,186,189,191,193,196,198,200,203,205,208,210,213,
+  215,218,220,223,225,228,231,233,236,239,241,244,247,249,252,255 };
+
+void setup() {
+  strip.setBrightness(BRIGHTNESS);
+  strip.begin();
+  strip.show(); // Initialize all pixels to 'off'
+}
+
+void loop() {
+  // Some example procedures showing how to display to the pixels:
+  // Do not run more than 15 seconds of these, or the b/g tasks
+  // will be blocked.
+  // --------------------------------------------------------------
+  colorWipe(strip.Color(255, 0, 0), 50); // Red
+  colorWipe(strip.Color(0, 255, 0), 50); // Green
+  colorWipe(strip.Color(0, 0, 255), 50); // Blue
+  colorWipe(strip.Color(0, 0, 0, 255), 50); // White
+
+  whiteOverRainbow(20,75,5);
+
+  pulseWhite(5);
+
+  // fullWhite();
+  // delay(2000);
+
+  rainbowFade2White(3,3,1);
+}
+
+// Input a value 0 to 255 to get a color value.
+// The colours are a transition r - g - b - back to r.
+uint32_t Wheel(byte WheelPos) {
+  WheelPos = 255 - WheelPos;
+  if(WheelPos < 85) {
+    return strip.Color(255 - WheelPos * 3, 0, WheelPos * 3,0);
+  }
+  if(WheelPos < 170) {
+    WheelPos -= 85;
+    return strip.Color(0, WheelPos * 3, 255 - WheelPos * 3,0);
+  }
+  WheelPos -= 170;
+  return strip.Color(WheelPos * 3, 255 - WheelPos * 3, 0,0);
+}
+
+uint8_t red(uint32_t c) {
+  return (c >> 8);
+}
+uint8_t green(uint32_t c) {
+  return (c >> 16);
+}
+uint8_t blue(uint32_t c) {
+  return (c);
+}
+
+// Fill the dots one after the other with a color
+void colorWipe(uint32_t c, uint8_t wait) {
+  for(uint16_t i=0; i<strip.numPixels(); i++) {
+    strip.setPixelColor(i, c);
+    strip.show();
+    delay(wait);
+  }
+}
+
+void pulseWhite(uint8_t wait) {
+  for(int j = 0; j < 256 ; j++) {
+    for(uint16_t i=0; i<strip.numPixels(); i++) {
+      strip.setPixelColor(i, strip.Color(0,0,0, gamma[j] ) );
+    }
+    delay(wait);
+    strip.show();
+  }
+
+  for(int j = 255; j >= 0 ; j--){
+    for(uint16_t i=0; i<strip.numPixels(); i++) {
+      strip.setPixelColor(i, strip.Color(0,0,0, gamma[j] ) );
+    }
+    delay(wait);
+    strip.show();
+  }
+}
+
+
+void rainbowFade2White(uint8_t wait, int rainbowLoops, int whiteLoops) {
+  float fadeMax = 100.0;
+  int fadeVal = 0;
+  uint32_t wheelVal;
+  int redVal, greenVal, blueVal;
+
+  for(int k = 0 ; k < rainbowLoops ; k ++) {
+    for(int j=0; j<256; j++) { // 5 cycles of all colors on wheel
+      for(int i=0; i< strip.numPixels(); i++) {
+        wheelVal = Wheel(((i * 256 / strip.numPixels()) + j) & 255);
+
+        redVal = red(wheelVal) * float(fadeVal/fadeMax);
+        greenVal = green(wheelVal) * float(fadeVal/fadeMax);
+        blueVal = blue(wheelVal) * float(fadeVal/fadeMax);
+
+        strip.setPixelColor( i, strip.Color( redVal, greenVal, blueVal ) );
+      }
+
+      // First loop, fade in!
+      if(k == 0 && fadeVal < fadeMax-1) {
+        fadeVal++;
+      }
+      // Last loop, fade out!
+      else if(k == rainbowLoops - 1 && j > 255 - fadeMax ) {
+        fadeVal--;
+      }
+
+      strip.show();
+      delay(wait);
+    }
+  }
+
+  delay(500);
+
+  for(int k = 0 ; k < whiteLoops ; k ++) {
+    for(int j = 0; j < 256 ; j++) {
+      for(uint16_t i=0; i < strip.numPixels(); i++) {
+        strip.setPixelColor(i, strip.Color(0,0,0, gamma[j] ) );
+      }
+      strip.show();
+    }
+
+    delay(2000);
+    for(int j = 255; j >= 0 ; j--) {
+      for(uint16_t i=0; i < strip.numPixels(); i++) {
+        strip.setPixelColor(i, strip.Color(0,0,0, gamma[j] ) );
+      }
+      strip.show();
+    }
+  }
+
+  delay(500);
+}
+
+void whiteOverRainbow(uint8_t wait, uint8_t whiteSpeed, uint8_t whiteLength ) {
+
+  if(whiteLength >= strip.numPixels()) whiteLength = strip.numPixels() - 1;
+
+  int head = whiteLength - 1;
+  int tail = 0;
+  int loops = 3;
+  int loopNum = 0;
+  static unsigned long lastTime = 0;
+
+  while(true) {
+    for(int j=0; j<256; j++) {
+      for(uint16_t i=0; i<strip.numPixels(); i++) {
+        if( (i >= tail && i <= head)
+          || (tail > head && i >= tail)
+          || (tail > head && i <= head) ) {
+          strip.setPixelColor(i, strip.Color(0,0,0, 255 ) );
+        } else {
+          strip.setPixelColor(i, Wheel(((i * 256 / strip.numPixels()) + j) & 255));
+        }
+      }
+
+      if(millis() - lastTime > whiteSpeed) {
+        head++;
+        tail++;
+        if(head == strip.numPixels()) {
+          loopNum++;
+        }
+        lastTime = millis();
+      }
+
+      if(loopNum == loops) return;
+
+      head %= strip.numPixels();
+      tail %= strip.numPixels();
+      strip.show();
+      delay(wait);
+    }
+  }
+
+}
+
+void fullWhite() {
+  for(uint16_t i=0; i<strip.numPixels(); i++) {
+    strip.setPixelColor(i, strip.Color(0,0,0, 255 ) );
+  }
+  strip.show();
+}
+
+// Slightly different, this makes the rainbow equally distributed throughout
+void rainbowCycle(uint8_t wait) {
+  uint16_t i, j;
+
+  for(j=0; j<256 * 5; j++) { // 5 cycles of all colors on wheel
+    for(i=0; i< strip.numPixels(); i++) {
+      strip.setPixelColor(i, Wheel(((i * 256 / strip.numPixels()) + j) & 255));
+    }
+    strip.show();
+    delay(wait);
+  }
+}
+
+void rainbow(uint8_t wait) {
+  uint16_t i, j;
+
+  for(j=0; j<256; j++) {
+    for(i=0; i<strip.numPixels(); i++) {
+      strip.setPixelColor(i, Wheel((i+j) & 255));
+    }
+    strip.show();
+    delay(wait);
+  }
+}
+

--- a/firmware/neopixel.cpp
+++ b/firmware/neopixel.cpp
@@ -1,8 +1,11 @@
 /*-------------------------------------------------------------------------
-  Spark Core, Photon, P1 and Electron library to control WS2811/WS2812 based RGB
-  LED devices such as Adafruit NeoPixel strips.
-  Currently handles 800 KHz and 400kHz bitstream on Spark Core and Photon,
-  WS2812, WS2812B and WS2811.
+  Spark Core, Photon, P1 and Electron library to control WS2811/WS2812
+  based RGB LED devices such as Adafruit NeoPixel strips.
+
+  Supports:
+  - 800 KHz and 400kHz bitstream WS2812, WS2812B and WS2811
+  - 800 KHz bitstream SK6812RGBW (NeoPixel RGBW pixel strips)
+    (use 'SK6812RGBW' as PIXEL_TYPE)
 
   Also supports:
   - Radio Shack Tri-Color Strip with TM1803 controller 400kHz bitstream.
@@ -57,27 +60,54 @@
   #define pinLO(_pin) (PIN_MAP2[_pin].gpio_peripheral->BSRRH = PIN_MAP2[_pin].gpio_pin)
   #define pinHI(_pin) (PIN_MAP2[_pin].gpio_peripheral->BSRRL = PIN_MAP2[_pin].gpio_pin)
 #else
-  #error "*** PLATFORM_ID not supported by this library. PLATFORM should be Core, Photon, or P1 ***"
+  #error "*** PLATFORM_ID not supported by this library. PLATFORM should be Core, Photon, P1 or Electron ***"
 #endif
 // fast pin access
 #define pinSet(_pin, _hilo) (_hilo ? pinHI(_pin) : pinLO(_pin))
 
 Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, uint8_t t) :
-  numLEDs(n), numBytes(n*3), type(t), pin(p), brightness(0), pixels(NULL), endTime(0)
+  begun(false), type(t), brightness(0), pixels(NULL), endTime(0)
 {
-  if((pixels = (uint8_t *)malloc(numBytes))) {
-    memset(pixels, 0, numBytes);
-  }
+  updateLength(n);
+  setPin(p);
 }
 
 Adafruit_NeoPixel::~Adafruit_NeoPixel() {
-  if(pixels) free(pixels);
-  pinMode(pin, INPUT);
+  if (pixels) free(pixels);
+  if (pin >= 0) pinMode(pin, INPUT);
+}
+
+void Adafruit_NeoPixel::updateLength(uint16_t n) {
+  if (pixels) free(pixels); // Free existing data (if any)
+
+  // Allocate new data -- note: ALL PIXELS ARE CLEARED
+  numBytes = n * ((type == SK6812RGBW) ? 4 : 3);
+  if ((pixels = (uint8_t *)malloc(numBytes))) {
+    memset(pixels, 0, numBytes);
+    numLEDs = n;
+  } else {
+    numLEDs = numBytes = 0;
+  }
 }
 
 void Adafruit_NeoPixel::begin(void) {
-  pinMode(pin, OUTPUT);
-  digitalWrite(pin, LOW);
+  if (pin >= 0) {
+    pinMode(pin, OUTPUT);
+    digitalWrite(pin, LOW);
+  }
+  begun = true;
+}
+
+// Set the output pin number
+void Adafruit_NeoPixel::setPin(uint8_t p) {
+    if (begun && (pin >= 0)) {
+        pinMode(pin, INPUT);
+    }
+    pin = p;
+    if (begun) {
+        pinMode(p, OUTPUT);
+        digitalWrite(p, LOW);
+    }
 }
 
 void Adafruit_NeoPixel::show(void) {
@@ -91,18 +121,21 @@ void Adafruit_NeoPixel::show(void) {
   // rather than stalling for the latch.
   uint32_t wait_time; // wait time in microseconds.
   switch(type) {
-    case TM1803: // TM1803 = 24us reset pulse
-      wait_time = 24L;
-      break;
-    case TM1829: // TM1829 = 500us reset pulse
-      wait_time = 500L;
-      break;
+    case TM1803: { // TM1803 = 24us reset pulse
+        wait_time = 24L;
+      } break;
+    case SK6812RGBW: { // SK6812RGBW = 80us reset pulse
+        wait_time = 80L;
+      } break;
+    case TM1829: { // TM1829 = 500us reset pulse
+        wait_time = 500L;
+      } break;
     case WS2812B: // WS2812 & WS2812B = 50us reset pulse
     case WS2812B2:
     case WS2811: // WS2811 = 50us reset pulse
-    default:     // default = 50us reset pulse
-      wait_time = 50L;
-      break;
+    default: {   // default = 50us reset pulse
+        wait_time = 50L;
+      } break;
   }
   while((micros() - endTime) < wait_time);
   // endTime is a private member (rather than global var) so that multiple
@@ -112,15 +145,16 @@ void Adafruit_NeoPixel::show(void) {
   __disable_irq(); // Need 100% focus on instruction timing
 
   volatile uint32_t
-    c,    // 24-bit pixel color
-    mask; // 8-bit mask
+    c,    // 24-bit/32-bit pixel color
+    mask; // 1-bit mask
   volatile uint16_t i = numBytes; // Output loop counter
   volatile uint8_t
     j,              // 8-bit inner loop counter
    *ptr = pixels,   // Pointer to next byte
     g,              // Current green byte value
     r,              // Current red byte value
-    b;              // Current blue byte value
+    b,              // Current blue byte value
+    w;              // Current white byte value
 
   if(type == WS2812B) { // same as WS2812, 800 KHz bitstream
     while(i) { // While bytes left... (3 bytes = 1 pixel)
@@ -219,6 +253,109 @@ void Adafruit_NeoPixel::show(void) {
         }
         mask >>= 1;
       } while ( ++j < 24 ); // ... pixel done
+    } // end while(i) ... no more pixels
+  }
+  else if(type == SK6812RGBW) { // similar to WS2812, 800 KHz bitstream but with RGB+W components
+    while(i) { // While bytes left... (4 bytes = 1 pixel)
+      mask = 0x80000000; // reset the mask
+      i = i-4;      // decrement bytes remaining
+      r = *ptr++;   // Next red byte value
+      g = *ptr++;   // Next green byte value
+      b = *ptr++;   // Next blue byte value
+      w = *ptr++;   // Next white byte value
+      c = ((uint32_t)r << 24) | ((uint32_t)g << 16) | ((uint32_t)b <<  8) | w; // Pack the next 4 bytes to keep timing tight
+      j = 0;        // reset the 32-bit counter
+      do {
+        pinSet(pin, HIGH); // HIGH
+        if (c & mask) { // if masked bit is high
+          // SK6812RGBW spec         600ns HIGH
+          // WS2812 spec             700ns HIGH
+          // Adafruit on Arduino    (meas. 812ns)
+          // This lib on Spark Core (meas. 610ns)
+          // This lib on Photon     (meas. 608ns)
+          asm volatile(
+            "mov r0, r0" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+#if (PLATFORM_ID == 6) || (PLATFORM_ID == 8) || (PLATFORM_ID == 10) // Photon (6) or P1 (8) or Electron (10)
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t"
+#endif
+            ::: "r0", "cc", "memory");
+          // SK6812RGBW spec         600ns LOW
+          // WS2812 spec             600ns LOW
+          // Adafruit on Arduino    (meas. 436ns)
+          // This lib on Spark Core (meas. 598ns)
+          // This lib on Photon     (meas. 600ns)
+          pinSet(pin, LOW); // LOW
+          asm volatile(
+            "mov r0, r0" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t"
+#if (PLATFORM_ID == 6) || (PLATFORM_ID == 8) || (PLATFORM_ID == 10) // Photon (6) or P1 (8) or Electron (10)
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+#endif
+            ::: "r0", "cc", "memory");
+        }
+        else { // else masked bit is low
+          // SK6812RGBW spec         300ns HIGH
+          // WS2812 spec             350ns HIGH
+          // Adafruit on Arduino    (meas. 312ns)
+          // This lib on Spark Core (meas. 305ns)
+          // This lib on Photon     (meas. 308ns)
+          asm volatile(
+            "mov r0, r0" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+#if (PLATFORM_ID == 6) || (PLATFORM_ID == 8) || (PLATFORM_ID == 10) // Photon (6) or P1 (8) or Electron (10)
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t"
+#endif
+            ::: "r0", "cc", "memory");
+          // SK6812RGBW spec         900ns LOW
+          // WS2812 spec             800ns LOW
+          // Adafruit on Arduino    (meas. 938ns)
+          // This lib on Spark Core (meas. 904ns)
+          // This lib on Photon     (meas. 900ns)
+          pinSet(pin, LOW); // LOW
+          asm volatile(
+            "mov r0, r0" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+#if (PLATFORM_ID == 6) || (PLATFORM_ID == 8) || (PLATFORM_ID == 10) // Photon (6) or P1 (8) or Electron (10)
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t" "nop" "\n\t"
+            "nop" "\n\t"
+#endif
+            ::: "r0", "cc", "memory");
+        }
+        mask >>= 1;
+      } while ( ++j < 32 ); // ... pixel done
     } // end while(i) ... no more pixels
   }
   else if(type == WS2812B2) { // WS2812B with DWT timer
@@ -652,17 +789,9 @@ void Adafruit_NeoPixel::show(void) {
   endTime = micros(); // Save EOD time for latch on next call
 }
 
-// Set the output pin number
-void Adafruit_NeoPixel::setPin(uint8_t p) {
-  pinMode(pin, INPUT);
-  pin = p;
-  pinMode(p, OUTPUT);
-  digitalWrite(p, LOW);
-}
-
 // Set pixel color from separate R,G,B components:
 void Adafruit_NeoPixel::setPixelColor(
- uint16_t n, uint8_t r, uint8_t g, uint8_t b) {
+  uint16_t n, uint8_t r, uint8_t g, uint8_t b) {
   if(n < numLEDs) {
     if(brightness) { // See notes in setBrightness()
       r = (r * brightness) >> 8;
@@ -682,6 +811,47 @@ void Adafruit_NeoPixel::setPixelColor(
         *p++ = r;
         *p++ = b;
         *p = g;
+        break;
+      case WS2811: // WS2811 is RGB order
+      case TM1803: // TM1803 is RGB order
+      default:     // default is RGB order
+        *p++ = r;
+        *p++ = g;
+        *p = b;
+        break;
+    }
+  }
+}
+
+// Set pixel color from separate R,G,B,W components:
+void Adafruit_NeoPixel::setPixelColor(
+  uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t w) {
+  if(n < numLEDs) {
+    if(brightness) { // See notes in setBrightness()
+      r = (r * brightness) >> 8;
+      g = (g * brightness) >> 8;
+      b = (b * brightness) >> 8;
+      w = (w * brightness) >> 8;
+    }
+    uint8_t *p = &pixels[n * (type==SK6812RGBW?4:3)];
+    switch(type) {
+      case WS2812B: // WS2812 & WS2812B is GRB order.
+      case WS2812B2:
+        *p++ = g;
+        *p++ = r;
+        *p = b;
+        break;
+      case TM1829: // TM1829 is special RBG order
+        if(r == 255) r = 254; // 255 on RED channel causes display to be in a special mode.
+        *p++ = r;
+        *p++ = b;
+        *p = g;
+        break;
+      case SK6812RGBW: // SK6812RGBW is RGBW order
+        *p++ = r;
+        *p++ = g;
+        *p++ = b;
+        *p = w;
         break;
       case WS2811: // WS2811 is RGB order
       case TM1803: // TM1803 is RGB order
@@ -695,6 +865,7 @@ void Adafruit_NeoPixel::setPixelColor(
 }
 
 // Set pixel color from 'packed' 32-bit RGB color:
+// If RGB+W color, order of bytes is WRGB in packed 32-bit form
 void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c) {
   if(n < numLEDs) {
     uint8_t
@@ -706,26 +877,37 @@ void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c) {
       g = (g * brightness) >> 8;
       b = (b * brightness) >> 8;
     }
-    uint8_t *p = &pixels[n * 3];
+    uint8_t *p = &pixels[n * (type==SK6812RGBW?4:3)];
     switch(type) {
       case WS2812B: // WS2812 & WS2812B is GRB order.
-      case WS2812B2:
-        *p++ = g;
-        *p++ = r;
-        *p = b;
+      case WS2812B2: {
+          *p++ = g;
+          *p++ = r;
+          *p = b;
+        }
         break;
-      case TM1829: // TM1829 is special RBG order
-        if(r == 255) r = 254; // 255 on RED channel causes display to be in a special mode.
-        *p++ = r;
-        *p++ = b;
-        *p = g;
+      case TM1829: { // TM1829 is special RBG order
+          if(r == 255) r = 254; // 255 on RED channel causes display to be in a special mode.
+          *p++ = r;
+          *p++ = b;
+          *p = g;
+        }
+        break;
+      case SK6812RGBW: { // SK6812RGBW is RGBW order
+          uint8_t w = (uint8_t)(c >> 24);
+          *p++ = r;
+          *p++ = g;
+          *p++ = b;
+          *p = brightness ? ((w * brightness) >> 8) : w;
+        }
         break;
       case WS2811: // WS2811 is RGB order
       case TM1803: // TM1803 is RGB order
-      default:     // default is RGB order
-        *p++ = r;
-        *p++ = g;
-        *p = b;
+      default: {   // default is RGB order
+          *p++ = r;
+          *p++ = g;
+          *p = b;
+        }
         break;
     }
   }
@@ -735,18 +917,31 @@ void Adafruit_NeoPixel::setColor(uint16_t aLedNumber, byte aRed, byte aGreen, by
   return setPixelColor(aLedNumber, (uint8_t) aRed, (uint8_t) aGreen, (uint8_t) aBlue);
 }
 
+void Adafruit_NeoPixel::setColor(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite) {
+  return setPixelColor(aLedNumber, (uint8_t) aRed, (uint8_t) aGreen, (uint8_t) aBlue, (uint8_t) aWhite);
+}
+
 void Adafruit_NeoPixel::setColorScaled(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aScaling) {
   // scale RGB with a common brightness parameter
   setColor(aLedNumber, (aRed*aScaling)>>8, (aGreen*aScaling)>>8, (aBlue*aScaling)>>8);
 }
 
-byte Adafruit_NeoPixel::brightnessToPWM(byte aBrightness) {
-  static const byte pwmLevels[16] = { 0, 1, 2, 3, 4, 6, 8, 12, 23, 36, 48, 70, 95, 135, 190, 255 };
-  return pwmLevels[aBrightness>>4];
+void Adafruit_NeoPixel::setColorScaled(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite, byte aScaling) {
+  // scale RGB with a common brightness parameter
+  setColor(aLedNumber, (aRed*aScaling)>>8, (aGreen*aScaling)>>8, (aBlue*aScaling)>>8, (aWhite*aScaling)>>8);
 }
 
 void Adafruit_NeoPixel::setColorDimmed(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aBrightness) {
   setColorScaled(aLedNumber, aRed, aGreen, aBlue, brightnessToPWM(aBrightness));
+}
+
+void Adafruit_NeoPixel::setColorDimmed(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite, byte aBrightness) {
+  setColorScaled(aLedNumber, aRed, aGreen, aBlue, aWhite, brightnessToPWM(aBrightness));
+}
+
+byte Adafruit_NeoPixel::brightnessToPWM(byte aBrightness) {
+  static const byte pwmLevels[16] = { 0, 1, 2, 3, 4, 6, 8, 12, 23, 36, 48, 70, 95, 135, 190, 255 };
+  return pwmLevels[aBrightness>>4];
 }
 
 // Convert separate R,G,B into packed 32-bit RGB color.
@@ -755,27 +950,41 @@ uint32_t Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b) {
   return ((uint32_t)r << 16) | ((uint32_t)g <<  8) | b;
 }
 
+// Convert separate R,G,B,W into packed 32-bit WRGB color.
+// Packed format is always WRGB, regardless of LED strand color order.
+uint32_t Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w) {
+  return ((uint32_t)w << 24) | ((uint32_t)r << 16) | ((uint32_t)g <<  8) | b;
+}
+
 // Query color from previously-set pixel (returns packed 32-bit RGB value)
 uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
   if(n >= numLEDs) {
     // Out of bounds, return no color.
     return 0;
   }
-  uint8_t *p = &pixels[n * 3];
+
+  uint8_t *p = &pixels[n * (type==SK6812RGBW?4:3)];
   uint32_t c;
 
   switch(type) {
     case WS2812B: // WS2812 & WS2812B is GRB order.
-    case WS2812B2:
-      c = ((uint32_t)p[1] << 16) | ((uint32_t)p[0] <<  8) | (uint32_t)p[2];
+    case WS2812B2: {
+        c = ((uint32_t)p[1] << 16) | ((uint32_t)p[0] <<  8) | (uint32_t)p[2];
+      }
       break;
-    case TM1829: // TM1829 is special RBG order
-      c = ((uint32_t)p[0] << 16) | ((uint32_t)p[2] <<  8) | (uint32_t)p[1];
+    case TM1829: { // TM1829 is special RBG order
+        c = ((uint32_t)p[0] << 16) | ((uint32_t)p[2] <<  8) | (uint32_t)p[1];
+      }
+      break;
+    case SK6812RGBW: { // SK6812RGBW is RGBW order, but returns packed WRGB color
+        c = ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] <<  8) | (uint32_t)p[3];
+      }
       break;
     case WS2811: // WS2811 is RGB order
     case TM1803: // TM1803 is RGB order
-    default:     // default is RGB order
-      c = ((uint32_t)p[0] << 16) | ((uint32_t)p[1] <<  8) | (uint32_t)p[2];
+    default: {   // default is RGB order
+        c = ((uint32_t)p[0] << 16) | ((uint32_t)p[1] <<  8) | (uint32_t)p[2];
+      }
       break;
   }
 
@@ -784,6 +993,9 @@ uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
   if(brightness) { // See notes in setBrightness()
     //Cast the color to a byte array
     uint8_t * c_ptr =reinterpret_cast<uint8_t*>(&c);
+    if (type == SK6812RGBW) {
+      c_ptr[3] = (c_ptr[3] << 8)/brightness;
+    }
     c_ptr[0] = (c_ptr[0] << 8)/brightness;
     c_ptr[1] = (c_ptr[1] << 8)/brightness;
     c_ptr[2] = (c_ptr[2] << 8)/brightness;

--- a/firmware/neopixel.h
+++ b/firmware/neopixel.h
@@ -1,8 +1,11 @@
 /*-------------------------------------------------------------------------
-  Spark Core, Photon, P1 and Electron library to control WS2811/WS2812 based RGB
-  LED devices such as Adafruit NeoPixel strips.
-  Currently handles 800 KHz and 400kHz bitstream on Spark Core and Photon,
-  WS2812, WS2812B and WS2811.
+  Spark Core, Photon, P1 and Electron library to control WS2811/WS2812
+  based RGB LED devices such as Adafruit NeoPixel strips.
+
+  Supports:
+  - 800 KHz and 400kHz bitstream WS2812, WS2812B and WS2811
+  - 800 KHz bitstream SK6812RGBW (NeoPixel RGBW pixel strips)
+    (use 'SK6812RGBW' as PIXEL_TYPE)
 
   Also supports:
   - Radio Shack Tri-Color Strip with TM1803 controller 400kHz bitstream.
@@ -53,12 +56,13 @@
 #include "application.h"
 
 // 'type' flags for LED pixels (third parameter to constructor):
+#define WS2811   0x00 // 400 KHz datastream (NeoPixel)
 #define WS2812   0x02 // 800 KHz datastream (NeoPixel)
 #define WS2812B  0x02 // 800 KHz datastream (NeoPixel)
-#define WS2811   0x00 // 400 KHz datastream (NeoPixel)
 #define TM1803   0x03 // 400 KHz datastream (Radio Shack Tri-Color Strip)
 #define TM1829   0x04 // 800 KHz datastream ()
 #define WS2812B2 0x05 // 800 KHz datastream (NeoPixel)
+#define SK6812RGBW 0x06 // 800 KHz datastream (NeoPixel RGBW)
 
 class Adafruit_NeoPixel {
 
@@ -73,11 +77,16 @@ class Adafruit_NeoPixel {
     show(void) __attribute__((optimize("Ofast"))),
     setPin(uint8_t p),
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
+    setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t w),
     setPixelColor(uint16_t n, uint32_t c),
     setBrightness(uint8_t),
     setColor(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue),
+    setColor(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite),
     setColorScaled(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aScaling),
+    setColorScaled(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite, byte aScaling),
     setColorDimmed(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aBrightness),
+    setColorDimmed(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite, byte aBrightness),
+    updateLength(uint16_t n),
     clear(void);
   uint8_t
    *getPixels() const,
@@ -86,7 +95,8 @@ class Adafruit_NeoPixel {
     numPixels(void) const,
     getNumLeds(void) const;
   static uint32_t
-    Color(uint8_t r, uint8_t g, uint8_t b);
+    Color(uint8_t r, uint8_t g, uint8_t b),
+    Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w);
   uint32_t
     getPixelColor(uint16_t n) const;
   byte
@@ -94,7 +104,9 @@ class Adafruit_NeoPixel {
 
  private:
 
-  const uint16_t
+  bool
+    begun;         // true if begin() previously called
+  uint16_t
     numLEDs,       // Number of RGB LEDs in strip
     numBytes;      // Size of 'pixels' buffer below
   const uint8_t

--- a/spark.json
+++ b/spark.json
@@ -2,7 +2,7 @@
   "name": "neopixel",
   "author": "Adafruit, Technobly",
   "license": "GNU GPLv3",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "An Implementation of Adafruit's NeoPixel Library for the Spark Core, Photon, P1 and Electron",
   "namespace": "Adafruit_NeoPixel"
 }


### PR DESCRIPTION
- Tested on an [Adafruit 24-pixel NeoPixel RGBW natural white ring](https://www.adafruit.com/products/2862), on Photon and Core.
- New RGBW PIXEL_TYPE is `SK6812RGBW`
- Added new `rgbw-strandtest.cpp` Example
- Added more info to the README.md
- Added these new RGBW functions:
  - `setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t w);`
  - `Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w);`
  - `setColor(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite);`
  - `setColorScaled(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite, byte aScaling);`
  - `setColorDimmed(uint16_t aLedNumber, byte aRed, byte aGreen, byte aBlue, byte aWhite, byte aBrightness);`
- Added this new function to dynamically modify the number of pixels at runtime
  - `updateLength(uint16_t n);`
- Updated library version to 0.0.9
