### PR TITLE
Delete copy constructor to prevent access to deallocated memory.

### DIFF
--- a/firmware/neopixel.h
+++ b/firmware/neopixel.h
@@ -72,6 +72,9 @@ class Adafruit_NeoPixel {
   Adafruit_NeoPixel(uint16_t n, uint8_t p=2, uint8_t t=WS2812B);
   ~Adafruit_NeoPixel();
 
+  // Remove copy constructor to prevent access to deallocated memory
+  Adafruit_NeoPixel(const Adafruit_NeoPixel&) = delete;
+
   void
     begin(void),
     show(void) __attribute__((optimize("Ofast"))),


### PR DESCRIPTION
Without this, it is possible to create a copy of the object by accident. When the copy goes out of scope, internal memory ("pixels") is freed, after which any calls to the original object (or further copies) accesses deallocated memory and crashes the device.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/technobly/sparkcore-neopixel/31)

<!-- Reviewable:end -->
