### PR TITLE
removed copy ctor init from all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Example Usage
 See this [flashable, rainbow example](firmware/examples/a-rainbow.cpp) for details, or, in a nutshell:
 
 ```cpp
-Adafruit_NeoPixel strip = Adafruit_NeoPixel(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
+Adafruit_NeoPixel strip(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
 void setup() {
   strip.begin();
   strip.show();
@@ -69,7 +69,7 @@ More Detailed Example Usage
 //                   (Radio Shack Tri-Color LED Strip - TM1803 driver
 //                    NOTE: RS Tri-Color LED's are grouped in sets of 3)
 
-Adafruit_NeoPixel strip = Adafruit_NeoPixel(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
+Adafruit_NeoPixel strip(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
 
 // IMPORTANT: To reduce NeoPixel burnout risk, add 1000 uF capacitor across
 // pixel power leads, add 300 - 500 Ohm resistor on first pixel's data input

--- a/firmware/examples/a-rainbow.cpp
+++ b/firmware/examples/a-rainbow.cpp
@@ -16,7 +16,7 @@ SYSTEM_MODE(AUTOMATIC);
 #define PIXEL_COUNT 10
 #define PIXEL_TYPE WS2812B
 
-Adafruit_NeoPixel strip = Adafruit_NeoPixel(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
+Adafruit_NeoPixel strip(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
 
 // Prototypes for local build, ok to leave in for Build IDE
 void rainbow(uint8_t wait);

--- a/firmware/examples/extra-examples.cpp
+++ b/firmware/examples/extra-examples.cpp
@@ -74,7 +74,7 @@ SYSTEM_MODE(AUTOMATIC);
 //                   (Radio Shack Tri-Color LED Strip - TM1803 driver
 //                    NOTE: RS Tri-Color LED's are grouped in sets of 3)
 
-Adafruit_NeoPixel strip = Adafruit_NeoPixel(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
+Adafruit_NeoPixel strip(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
 
 // IMPORTANT: To reduce NeoPixel burnout risk, add 1000 uF capacitor across
 // pixel power leads, add 300 - 500 Ohm resistor on first pixel's data input

--- a/firmware/examples/rgbw-strandtest.cpp
+++ b/firmware/examples/rgbw-strandtest.cpp
@@ -35,7 +35,7 @@ SYSTEM_MODE(AUTOMATIC);
 #define PIXEL_TYPE SK6812RGBW
 #define BRIGHTNESS 50 // 0 - 255
 
-Adafruit_NeoPixel strip = Adafruit_NeoPixel(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
+Adafruit_NeoPixel strip(PIXEL_COUNT, PIXEL_PIN, PIXEL_TYPE);
 
 int gamma[] = {
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,


### PR DESCRIPTION
PR #31 remove the copy ctor, which broke all the examples (see issue #34). I changed all the examples to initialize `strip` using the default ctor instead of copy ctor.