### PR TITLE
Added M-SoM Compatibility

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=neopixel
-version=1.0.4
+version=1.0.5
 license=LGPLv3
 author=Adafruit, Technobly
-sentence=An Implementation of Adafruit's NeoPixel Library for the Particle Core, Photon, Electron, Argon, Boron, Xenon, RedBear Duo, B SoM, B5 SoM, E SoM X, P2, Photon 2,  and Tracker
+sentence=An Implementation of Adafruit's NeoPixel Library for the Particle Core, Photon, Electron, Argon, Boron, Xenon, RedBear Duo, B SoM, B5 SoM, E SoM X, P2, Photon 2, M SoM and Tracker
 url=https://github.com/technobly/Particle-NeoPixel
 repository=https://github.com/technobly/Particle-NeoPixel.git

--- a/src/neopixel.h
+++ b/src/neopixel.h
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------
-  Particle Core, Particle Photon, P1, Electron, Argon, Boron, Xenon, B SoM, B5 SoM, E SoM X, P2, Photon 2, Tracker and
+  Particle Core, Particle Photon, P1, Electron, Argon, Boron, Xenon, B SoM, B5 SoM, E SoM X, P2, Photon 2, M SoM Tracker and
   RedBear Duo library to control WS2811/WS2812/WS2813 based RGB LED
   devices such as Adafruit NeoPixel strips.
 
@@ -73,11 +73,11 @@ class Adafruit_NeoPixel {
  public:
 
   // Constructor: number of LEDs, pin number, LED type
-#if (PLATFORM_ID == 32)
+#if (PLATFORM_ID == 32 || PLATFORM_ID == 35)
   Adafruit_NeoPixel(uint16_t n, SPIClass& spi, uint8_t t=WS2812B);
 #else
   Adafruit_NeoPixel(uint16_t n, uint8_t p=2, uint8_t t=WS2812B);
-#endif // #if (PLATFORM_ID == 32)
+#endif // #if (PLATFORM_ID == 32 || PLATFORM_ID == 35)
   ~Adafruit_NeoPixel();
 
   void
@@ -127,7 +127,7 @@ class Adafruit_NeoPixel {
    *pixels;        // Holds LED color values (3 bytes each)
   uint32_t
     endTime;       // Latch timing reference
-#if (PLATFORM_ID == 32)
+#if (PLATFORM_ID == 32 || PLATFORM_ID == 35)
   SPIClass*
     spi_;
 #endif


### PR DESCRIPTION
Added proper HAL flags for M-SoM compatibility. 

Perhaps instead of platform_id == 32 or 35, we could use HAL_PLATFORM_RTL872X for automatic support of any new RTL872X devices. 

I did not want to modify the methodology of the previous implementation without requesting

zcfearns